### PR TITLE
Undo Edit

### DIFF
--- a/lib/sudoku_sayfasi.dart
+++ b/lib/sudoku_sayfasi.dart
@@ -429,6 +429,7 @@ class _SudokuSayfasiState extends State<SudokuSayfasi> {
                                         _sudokuKutu.put('ipucu', onceki['ipucu']);
 
                                         _sudokuKutu.put('sudokuHistory', _sudokuHistory);
+                                        _sudoku = onceki['sudokuRows']; // Sayılar geri alındıktan sonra farklı bir sayı girildiğinde silinen sayıların geri dönmemesi için
                                       }
 
                                       print(_sudokuHistory.length);


### PR DESCRIPTION
Mehmet hocam merhaba, sudokunun geri butonu kullanıldıktan sonra, farklı bir rakam girildiğinde, silinen öğeler geri geliyor. Çünkü, history kayıtları silinse bile _sudo kayıtlarını değiştirmedik.